### PR TITLE
[FEAT] 마이페이지 API 추가

### DIFF
--- a/src/features/auth/auth.controller.ts
+++ b/src/features/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Post, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { Response } from 'express';
@@ -7,6 +7,7 @@ import { User } from '../users/entities/user.entity';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { UpdateMeDto } from './dto/update-me.dto';
 
 const COOKIE_OPTIONS = {
   httpOnly: true,
@@ -59,6 +60,20 @@ export class AuthController {
       maxAge: 15 * 60 * 1000,
     });
     return { message: '토큰이 갱신되었습니다.' };
+  }
+
+  @ApiOperation({ summary: '내 정보 조회' })
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  getMe(@CurrentUser() user: User) {
+    return this.authService.getMe(user);
+  }
+
+  @ApiOperation({ summary: '내 정보 수정' })
+  @UseGuards(AuthGuard('jwt'))
+  @Patch('me')
+  updateMe(@CurrentUser() user: User, @Body() dto: UpdateMeDto) {
+    return this.authService.updateMe(user.id, dto);
   }
 
   @ApiOperation({ summary: '로그아웃' })

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -101,11 +101,7 @@ export class AuthService {
   }
 
   getMe(user: User) {
-    return {
-      data: {
-        user: { id: user.id, email: user.email, name: user.name, role: user.role },
-      },
-    };
+    return { id: user.id, email: user.email, name: user.name, role: user.role };
   }
 
   async updateMe(userId: number, dto: UpdateMeDto) {

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -9,9 +9,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
 import { Repository } from 'typeorm';
 import { Cart } from '../cart/entities/cart.entity';
+import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { UpdateMeDto } from './dto/update-me.dto';
 
 @Injectable()
 export class AuthService {
@@ -96,5 +98,25 @@ export class AuthService {
   async logout(userId: number) {
     await this.usersService.updateRefreshToken(userId, null);
     return { message: '로그아웃되었습니다.' };
+  }
+
+  getMe(user: User) {
+    return {
+      data: {
+        user: { id: user.id, email: user.email, name: user.name, role: user.role },
+      },
+    };
+  }
+
+  async updateMe(userId: number, dto: UpdateMeDto) {
+    const updated = dto.name
+      ? await this.usersService.updateName(userId, dto.name)
+      : await this.usersService.findById(userId);
+
+    return {
+      data: {
+        user: { id: updated!.id, email: updated!.email, name: updated!.name, role: updated!.role },
+      },
+    };
   }
 }

--- a/src/features/auth/dto/update-me.dto.ts
+++ b/src/features/auth/dto/update-me.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateMeDto {
+  @ApiPropertyOptional({ description: '변경할 이름' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+}

--- a/src/features/users/users.service.ts
+++ b/src/features/users/users.service.ts
@@ -23,6 +23,11 @@ export class UsersService {
     return this.userRepository.save(user);
   }
 
+  async updateName(userId: number, name: string): Promise<User> {
+    await this.userRepository.update(userId, { name });
+    return this.userRepository.findOne({ where: { id: userId } }) as Promise<User>;
+  }
+
   async updateRefreshToken(
     userId: number,
     refreshToken: string | null,


### PR DESCRIPTION
## 관련 이슈

<!-- 관련된 이슈가 있다면 연결해주세요 (머지 시 자동으로 이슈가 닫힙니다) -->
Closes #16 

## 요약

 - `GET /auth/me`: 로그인한 사용자의 정보(id, email, name, role) 조회                                                                                                                                     
  - `PATCH /auth/me`: 이름 수정 기능 추가                                                                                                                                                                  
  - `role` 필드 응답에 포함하여 클라이언트에서 어드민 여부 판별 가능                      

## 변경 사항

<!-- 주요 변경 사항을 나열해주세요 -->
  - `update-me.dto.ts`: 내 정보 수정 요청 DTO 추가                                                                                                                                                         
  - `users.service.ts`: `updateName()` 메서드 추가                                                                                                                                                         
  - `auth.service.ts`: `getMe()`, `updateMe()` 메서드 추가                                                                                                                                                 
  - `auth.controller.ts`: `GET /auth/me`, `PATCH /auth/me` 엔드포인트 추가  

  ## Auth                                                                                                                                                                                                  
  - 기존 `/auth/login`, `/auth/logout`과 동일한 쿠키 기반 JWT 인증 사용                                                                                                                                  
  - 미인증 요청 시 401 반환                                                                                                                                                                                
                               