### PR TITLE
[FEAT] 마이페이지 및 어드민 사용자 관리 API 추가

### DIFF
--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -109,10 +109,6 @@ export class AuthService {
       ? await this.usersService.updateName(userId, dto.name)
       : await this.usersService.findById(userId);
 
-    return {
-      data: {
-        user: { id: updated!.id, email: updated!.email, name: updated!.name, role: updated!.role },
-      },
-    };
+    return { id: updated!.id, email: updated!.email, name: updated!.name, role: updated!.role };
   }
 }

--- a/src/features/cart/cart.service.ts
+++ b/src/features/cart/cart.service.ts
@@ -57,7 +57,7 @@ export class CartService {
     userId: number,
     itemId: number,
     dto: UpdateCartItemDto,
-  ): Promise<CartItem | void> {
+  ): Promise<CartItem | { message: string }> {
     const cart = await this.getCart(userId);
     const item = await this.cartItemRepository.findOne({
       where: { id: itemId, cartId: cart.id },
@@ -69,14 +69,14 @@ export class CartService {
 
     if (dto.quantity === 0) {
       await this.cartItemRepository.remove(item);
-      return;
+      return { message: '장바구니 상품이 삭제되었습니다.' };
     }
 
     item.quantity = dto.quantity;
     return this.cartItemRepository.save(item);
   }
 
-  async removeItem(userId: number, itemId: number): Promise<void> {
+  async removeItem(userId: number, itemId: number): Promise<{ message: string }> {
     const cart = await this.getCart(userId);
     const item = await this.cartItemRepository.findOne({
       where: { id: itemId, cartId: cart.id },
@@ -87,10 +87,12 @@ export class CartService {
     }
 
     await this.cartItemRepository.remove(item);
+    return { message: '장바구니 상품이 삭제되었습니다.' };
   }
 
-  async clearCart(userId: number): Promise<void> {
+  async clearCart(userId: number): Promise<{ message: string }> {
     const cart = await this.getCart(userId);
     await this.cartItemRepository.delete({ cartId: cart.id });
+    return { message: '장바구니가 비워졌습니다.' };
   }
 }

--- a/src/features/products/products.service.ts
+++ b/src/features/products/products.service.ts
@@ -72,8 +72,9 @@ export class ProductsService {
     return this.productRepository.save(product);
   }
 
-  async remove(id: number): Promise<void> {
+  async remove(id: number): Promise<{ message: string }> {
     const product = await this.findOne(id);
     await this.productRepository.remove(product);
+    return { message: '상품이 삭제되었습니다.' };
   }
 }

--- a/src/features/users/users.controller.ts
+++ b/src/features/users/users.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { UserRole } from './entities/user.entity';
+import { UsersService } from './users.service';
+
+@ApiTags('Users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin/users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @ApiOperation({ summary: '사용자 목록 조회 (어드민)' })
+  @Get()
+  findAll() {
+    return this.usersService.findAll();
+  }
+
+  @ApiOperation({ summary: '사용자 상세 조회 (어드민)' })
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.usersService.findOneOrFail(id);
+  }
+}

--- a/src/features/users/users.module.ts
+++ b/src/features/users/users.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/src/features/users/users.service.ts
+++ b/src/features/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
@@ -21,6 +21,23 @@ export class UsersService {
   async create(data: Partial<User>): Promise<User> {
     const user = this.userRepository.create(data);
     return this.userRepository.save(user);
+  }
+
+  async findAll(): Promise<User[]> {
+    return this.userRepository.find({
+      select: ['id', 'email', 'name', 'role', 'createdAt'],
+    });
+  }
+
+  async findOneOrFail(userId: number): Promise<User> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      select: ['id', 'email', 'name', 'role', 'createdAt'],
+    });
+    if (!user) {
+      throw new NotFoundException('존재하지 않는 사용자입니다.');
+    }
+    return user;
   }
 
   async updateName(userId: number, name: string): Promise<User> {


### PR DESCRIPTION
## 관련 이슈

<!-- 관련된 이슈가 있다면 연결해주세요 (머지 시 자동으로 이슈가 닫힙니다) -->
Closes #18 

## 요약

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
                                                                                                                                                                                                          
  마이페이지 조회/수정 엔드포인트와 어드민용 사용자 관리 API를 추가하고,                                                                                                                                   
  전체 API 응답 형식의 일관성을 수정했습니다.                   

## 변경 사항

                                                                                                                                                                                                           
  ### feat                                                                                                                                                                                                 
  - `GET /auth/me` — 내 정보 조회
  - `PATCH /auth/me` — 내 이름 수정                                                                                                                                                                        
  - `GET /admin/users` — 사용자 목록 조회 (어드민 전용)                                                                                                                                                    
  - `GET /admin/users/:id` — 사용자 상세 조회 (어드민 전용)                                                                                                                                                
                                                                                                                                                                                                           
  ### fix                                                                                                                                                                                                  
  - `PATCH /auth/me` 응답에서 `data` 이중 중첩 제거                                                                                                                                                        
  - `DELETE` 및 void 반환 엔드포인트에 명시적 메시지 응답 추가                                                                                                                                             
    - `DELETE /cart/items/:itemId`, `DELETE /cart`, `DELETE /products/:id`   

 ## 응답 형식                                                                                                                                                                                             
                                                                                                                                                                                                           
  모든 엔드포인트가 `ResponseInterceptor`를 통해 일관된 구조로 응답합니다.                                                                                                                                 
                  
  | 구분 | 형식 |                                                                                                                                                                                          
  |------|------| 
  | 성공 | `{ "data": ... }` |                                                                                                                                                                             
  | 페이지네이션 | `{ "data": [...], "total", "page", "limit" }` |                                                                                                                                         
  | 에러 | `{ "message", "status", "code", "path", "timestamp" }` |                                                                                                                                        
                                                                        